### PR TITLE
docs: add API key setup and bearer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# RAG Application
+
+## Installation
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Set multiple API keys:
+
+```bash
+export API_KEYS="key1,key2"
+```
+
+## Endpoints
+
+Example request with Bearer token header:
+
+```bash
+curl -H "Authorization: Bearer key1" http://localhost:8000/v1/example
+```
+


### PR DESCRIPTION
## Summary
- document how to export multiple API keys
- show example request with Authorization bearer token

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b802d2df448322975184002bd501d6