### PR TITLE
docs: recommend using virtual env

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 Requires Python 3.10+.
 
-Install dependencies:
+Create and activate a virtual environment before installing dependencies:
 
 ```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use: .venv\\Scripts\\activate
 pip install -r requirements.txt
 ```
 
@@ -25,11 +27,13 @@ running directly with Python, set the `PORT` environment variable before
 launching:
 
 ```bash
+# from the project root, with the virtual environment activated
 export PORT=9000
 python app.py
 ```
 
-If you run the app with an ASGI server like Uvicorn or Gunicorn, you can set the
+If you run the app with an ASGI server like Uvicorn or Gunicorn, ensure your
+virtual environment is active. You can set the
 port with the same environment variable or by using their command‑line options:
 
 ```bash


### PR DESCRIPTION
## Summary
- document creating and activating a Python virtual environment before installing dependencies
- note that the app should be run with the virtual environment activated

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy, no matching distribution found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b813e974688322a02bd29192430d2d