### PR TITLE
Expose additional GPU API models in model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
 
+## Supported API Models
+
+The application can use the following GPU API models:
+
+- jarvik-rag:latest
+- everythinglm:13b-16k
+- jarvik-chat:latest
+- jarvik-coder:latest
+- CognitiveComputations/dolphin-llama3.1:8b
+- dolphincoder:15b-starcoder2-q5_K_M
+- gpt-oss:latest
+- starcoder:7b
+- mistral:7b
+- codellama:7b-instruct
+- nous-hermes2:latest
+- command-r:latest
+- llama3:8b
+
 ## Installation
 
 Requires Python 3.10+.

--- a/app.py
+++ b/app.py
@@ -82,7 +82,7 @@ def _init_gpu_client():
         except Exception as e2:
             GPU_ERR = f"{type(e).__name__}: {e} | RAW /models FAIL -> {type(e2).__name__}: {e2}"
 
-def gpu_preflight_models(max_show: int = 7) -> str:
+def gpu_preflight_models(max_show: int = 20) -> str:
     """Vrátí string s informací o dostupnosti GPU API (seznam modelů nebo chybu)."""
     if GPU_CLIENT is None:
         _init_gpu_client()
@@ -326,6 +326,12 @@ class App(tk.Tk):
         ttk.Label(top, text="Model:").pack(side="left", padx=(8, 0))
         self.models_cpu = list_local_models()
         self.models_gpu = [
+            "gpu:jarvik-rag:latest",
+            "gpu:everythinglm:13b-16k",
+            "gpu:jarvik-chat:latest",
+            "gpu:jarvik-coder:latest",
+            "gpu:CognitiveComputations/dolphin-llama3.1:8b",
+            "gpu:dolphincoder:15b-starcoder2-q5_K_M",
             "gpu:gpt-oss:latest",
             "gpu:starcoder:7b",
             "gpu:mistral:7b",
@@ -336,7 +342,13 @@ class App(tk.Tk):
         ]
         all_models = self.models_cpu + self.models_gpu
         self.model_var = tk.StringVar(value="")
-        self.model_cb = ttk.Combobox(top, textvariable=self.model_var, values=all_models, state="readonly", width=38)
+        self.model_cb = ttk.Combobox(
+            top,
+            textvariable=self.model_var,
+            values=all_models,
+            state="readonly",
+            width=60,
+        )
         self.model_cb.pack(side="left", padx=(0, 8))
         ttk.Button(top, text="Refresh", command=self.refresh_models).pack(side="left")
 


### PR DESCRIPTION
## Summary
- add new GPU API models like `jarvik-rag:latest`, `everythinglm:13b-16k`, and more to the model selector
- document all supported API models in the README
- widen model dropdown and allow listing more models from the GPU API

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ba272bb410832297337be4ba207b00